### PR TITLE
Feat backend : Revison

### DIFF
--- a/app/Http/Controllers/Pelanggan/ReservasiController.php
+++ b/app/Http/Controllers/Pelanggan/ReservasiController.php
@@ -203,9 +203,9 @@ class ReservasiController extends Controller
             // Update related reservation status if needed
             if ($pembayaran->status == 'completed') {
                 $pembayaran->reservasi()->update(['status' => 'confirmed']);
+                Mail::to($pembayaran->reservasi->user->email)->send(new SendInvoices($pembayaran->reservasi));
             }
 
-            Mail::to($pembayaran->reservasi->user->email)->send(new SendInvoices($pembayaran->reservasi));
             return redirect()->route('pelanggan.riwayat')->with('success', 'Reservasi berhasil dibuat');
         } catch (\Exception $e) {
             Log::error('Payment notification error: ' . $e->getMessage());

--- a/app/Http/Controllers/Pelanggan/RiwayatController.php
+++ b/app/Http/Controllers/Pelanggan/RiwayatController.php
@@ -44,7 +44,7 @@ class RiwayatController extends Controller
                 ],
             ];
 
-            $reservasi->pembayaran->update(['order_id' => $newOrderId]);
+            $reservasi->pembayaran->update(['transaksi_id' => $newOrderId]);
             $reservasi->update(['status' => 'pending']);
             $reservasi->pembayaran->save();
             $reservasi->save();

--- a/app/Http/Controllers/Pelanggan/RiwayatController.php
+++ b/app/Http/Controllers/Pelanggan/RiwayatController.php
@@ -30,10 +30,11 @@ class RiwayatController extends Controller
 
     public function pay(Reservasi $reservasi)
     {
+        $newOrderId = 'TRX' . time();
         try {
             $params = [
                 'transaction_details' => [
-                    'order_id' => $reservasi->pembayaran->transaksi_id,
+                    'order_id' => $newOrderId,
                     'gross_amount' => $reservasi->pembayaran->jumlah,
                 ],
                 'customer_details' => [
@@ -42,6 +43,11 @@ class RiwayatController extends Controller
                     'phone' => $reservasi->user->no_telepon,
                 ],
             ];
+
+            $reservasi->pembayaran->update(['order_id' => $newOrderId]);
+            $reservasi->update(['status' => 'pending']);
+            $reservasi->pembayaran->save();
+            $reservasi->save();
 
             $snapToken = Snap::getSnapToken($params);
             return response()->json(['snapToken' => $snapToken]);

--- a/resources/views/pelanggan/reservasi/index.blade.php
+++ b/resources/views/pelanggan/reservasi/index.blade.php
@@ -433,7 +433,6 @@
                                 });
                             },
                             onPending: function(result) {
-                                console.log(result);
                                 Swal.fire({
                                     title: 'Pembayaran Pending',
                                     text: 'Silakan selesaikan pembayaran Anda sesuai instruksi yang diberikan',
@@ -446,7 +445,6 @@
                                 });
                             },
                             onError: function(result) {
-                                console.log(result);
                                 Swal.fire({
                                     title: 'Pembayaran Gagal',
                                     text: 'Terjadi kesalahan dalam proses pembayaran',

--- a/resources/views/pelanggan/riwayat/index.blade.php
+++ b/resources/views/pelanggan/riwayat/index.blade.php
@@ -158,10 +158,28 @@
                         if (data.snapToken) {
                             snap.pay(data.snapToken, {
                                 onSuccess: function(result) {
-                                    window.location.reload();
+                                    Swal.fire({
+                                        title: 'Pembayaran Berhasil!',
+                                        text: 'Reservasi Anda telah dikonfirmasi. Silakan cek email Anda untuk invoice.',
+                                        icon: 'success',
+                                        showConfirmButton: false,
+                                        timer: 2000,
+                                    }).then(() => {
+                                        window.location.href =
+                                            `/midtrans/notification?order_id=${result.order_id}&status_code=${result.status_code}&transaction_status=${result.transaction_status}&payment_type=${result.payment_type}`;
+                                    });
                                 },
                                 onPending: function(result) {
-                                    window.location.reload();
+                                    Swal.fire({
+                                        title: 'Pembayaran Pending',
+                                        text: 'Silakan selesaikan pembayaran Anda sesuai instruksi yang diberikan',
+                                        icon: 'warning',
+                                        showConfirmButton: false,
+                                        timer: 2000,
+                                    }).then(() => {
+                                        window.location.href =
+                                            `/midtrans/notification?order_id=${result.order_id}&status_code=${result.status_code}&transaction_status=${result.transaction_status}`;
+                                    });
                                 },
                                 onError: function(result) {
                                     Swal.fire({
@@ -170,6 +188,9 @@
                                         icon: 'error',
                                         showConfirmButton: false,
                                         timer: 2000
+                                    }).then(() => {
+                                        window.location.href =
+                                            `/midtrans/notification?order_id=${result.order_id}&status_code=${result.status_code}&transaction_status=${result.transaction_status}`;
                                     });
                                 },
                                 onClose: function() {


### PR DESCRIPTION
This pull request includes several changes to improve the handling of payment notifications, reservation updates, and user notifications in the reservation system. The most important changes include updating the reservation status and sending invoices upon payment completion, generating new order IDs for transactions, and enhancing user notifications with SweetAlert pop-ups.

### Payment and Reservation Updates:

* [`app/Http/Controllers/Pelanggan/ReservasiController.php`](diffhunk://#diff-44dcd608ae7a1e5bd326026cc0e611af9d5858ea4e0886d4c5c6d13b5859e3e5R206-L208): Updated the `handlePaymentNotification` method to send invoices only when the payment status is 'completed'.
* [`app/Http/Controllers/Pelanggan/RiwayatController.php`](diffhunk://#diff-4252de99d6d58a53a13cf18c763ce7d4fdfaa13830bfeace3bc72b5bd96806e2R33-R37): Modified the `pay` method to generate a new order ID for each transaction, update the reservation and payment status, and save the changes. [[1]](diffhunk://#diff-4252de99d6d58a53a13cf18c763ce7d4fdfaa13830bfeace3bc72b5bd96806e2R33-R37) [[2]](diffhunk://#diff-4252de99d6d58a53a13cf18c763ce7d4fdfaa13830bfeace3bc72b5bd96806e2R47-R51)

### User Notifications:

* [`resources/views/pelanggan/riwayat/index.blade.php`](diffhunk://#diff-5e2e41820e3bb20f205c9094355921bf2312cacedbdb868da892684f0bb7acdfL161-R182): Enhanced the `getCsrfToken` function to use SweetAlert for success, pending, and error notifications, and redirect users to the appropriate URL after showing the alert. [[1]](diffhunk://#diff-5e2e41820e3bb20f205c9094355921bf2312cacedbdb868da892684f0bb7acdfL161-R182) [[2]](diffhunk://#diff-5e2e41820e3bb20f205c9094355921bf2312cacedbdb868da892684f0bb7acdfR191-R193)

### Code Cleanup:

* [`resources/views/pelanggan/reservasi/index.blade.php`](diffhunk://#diff-df3fd4573fc086f69c55cf592667ae1c61a8de349ecc116bc13670fb60b732b8L436): Removed unnecessary `console.log` statements in the `loadAvailableTimeSlots` function. [[1]](diffhunk://#diff-df3fd4573fc086f69c55cf592667ae1c61a8de349ecc116bc13670fb60b732b8L436) [[2]](diffhunk://#diff-df3fd4573fc086f69c55cf592667ae1c61a8de349ecc116bc13670fb60b732b8L449)