### PR TITLE
 feat: update jadwal barberman

### DIFF
--- a/resources/views/barberman/jadwal/index.blade.php
+++ b/resources/views/barberman/jadwal/index.blade.php
@@ -119,21 +119,25 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach ($jadwal as $index => $item)
+                @forelse ($jadwal as $index => $item)
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
                         <td class="font-medium text-gray-900 whitespace-nowrap dark:text-white">{{ $index + 1 }}</td>
-                        <td> 
-                            @if ($item->reservasi && $item->reservasi->first() && $item->reservasi->first()->user)
+                        <td>
+                            @if ($item->reservasi && $item->reservasi->isNotEmpty() && $item->reservasi->first() && $item->reservasi->first()->user)
                                 {{ $item->reservasi->first()->user->name }}
                             @else
-                                <span class="text-gray-400">Pelanggan Offline</span>
+                                <span class="text-gray-500"> pelanggan</span>
                             @endif
                         </td>
                         <td>{{ $item->tanggal }}</td>
                         <td>{{ $item->jam_mulai }}</td>
                         <td>{{ $item->jam_selesai }}</td>
                     </tr>
-                @endforeach
+                @empty
+                    <tr>
+                        <td colspan="5" class="text-center py-4 text-gray-500">Tidak ada jadwal yang tersedia</td>
+                    </tr>
+                @endforelse
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
This pull request updates the `index.blade.php` view for displaying barber schedules to improve the handling of empty data and enhance user feedback. The most important changes include replacing `@foreach` with `@forelse` to handle empty schedules gracefully and refining the display of customer information and placeholders.

### Improvements to empty state handling:
* Replaced `@foreach` with `@forelse` in the schedule table to handle cases where no schedules are available. An additional row is displayed with a message "Tidak ada jadwal yang tersedia" when the schedule list is empty.

### User feedback enhancements:
* Updated the placeholder text for offline customers from "Pelanggan Offline" to "pelanggan" and adjusted the text color to `text-gray-500` for consistency.
* Improved the condition to check if `reservasi` is not empty by using `isNotEmpty()` for better readability and accuracy.